### PR TITLE
20 update damsmdmjson content type

### DIFF
--- a/schemas/authored/damsmdm.json
+++ b/schemas/authored/damsmdm.json
@@ -1,5 +1,7 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
+	"title": "DAMS Metadata Model (DEPRECATED)",
+	"description": "This schema is deprecated. The DAMS metadata model derived from OTMM is no longer in active use.",
 	"type": "object",
 	"required": [
 		"uan",

--- a/schemas/authored/damsmdm.json
+++ b/schemas/authored/damsmdm.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "DAMS Metadata Model (DEPRECATED)",
-	"description": "This schema is deprecated. The DAMS metadata model derived from OTMM is no longer in active use.",
+	"description": "This schema is deprecated. The DAMS metadata model is no longer in active use.",
 	"type": "object",
 	"required": [
 		"uan",

--- a/schemas/content/damsmdm.json
+++ b/schemas/content/damsmdm.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"title": "The current dams medatadata model derived from OTMM",
+	"title": "DAMS Metadata Model (DEPRECATED) - derived from OTMM",
+	"description": "This schema is deprecated. The DAMS metadata model derived from OTMM is no longer in active use.",
 	"type": "object",
 	"required": [
 		"uan",

--- a/schemas/content/damsmdm.json
+++ b/schemas/content/damsmdm.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "DAMS Metadata Model (DEPRECATED) - derived from OTMM",
-	"description": "This schema is deprecated. The DAMS metadata model derived from OTMM is no longer in active use.",
+	"description": "This schema is deprecated. The DAMS metadata model is no longer in active use.",
 	"type": "object",
 	"required": [
 		"uan",


### PR DESCRIPTION
This pull request updates the DAMS metadata model schemas to indicate that they are deprecated and no longer in active use. This helps clarify the status of these schemas for future users and maintainers.

Deprecation updates:

* Added "DEPRECATED" to the `title` and included a `description` noting deprecation in `schemas/authored/damsmdm.json`.
* Updated the `title` to include "DEPRECATED" and added a deprecation `description` in `schemas/content/damsmdm.json`.