### PR TITLE
Updated README to be more comprehensive

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,57 @@
 
 EDAN (Enterprise Digital Asset Network) is a suite of services and technologies that centralizes access and distribution of the Smithsonian Institution's (SI) vast holdings of metadata and file content from its collections, archives, and libraries.
 
-EDAN schemas detail the `content` property of certain EDAN record
-types. They do not describe root-level properties such as id, url, title,
-or unitCode.
+## What an EDAN Record Looks Like
+
+An EDAN record has two layers:
+
+- A root record envelope containing fields such as id, title, unitCode, type, url, content, hash, docSignature, timestamp, version, and publicSearch.
+- A content object whose structure depends on the record type.
+
+The shared root record properties live in [core.json](core/core.json).
+
+## How the Content Model Works
+
+Many EDAN content schemas organize metadata into a compact set of top-level buckets rather than a single flat object. An ideal example is [edanmdm.json](schemas/content/edanmdm.json).
+
+These buckets separate metadata by purpose:
+
+* **descriptiveNonRepeating** : core descriptive data that is usually singular or canonical for the record.
+* **indexedStructured** : normalized values intended for faceting, filtering, sorting, and structured search.
+* **freetext** : display-oriented text grouped under dynamic field names, usually as arrays of label/content objects.
+* **descriptiveOptional** : additional descriptive data that is not required for the core identity of the record.
+
+This separation is important because the same concept may appear in more than one bucket for different reasons. For example, a place, name, or date may appear:
+
+* in **freetext** for labeled display text,
+* in **indexedStructured** for faceting and search,
+* in **descriptiveNonRepeating** when it is part of the record’s canonical description.
+
+That design allows EDAN to preserve source metadata while also supporting a wide array of search and presentation needs.
+
+
+## Common Top-Level Content Buckets
+
+### descriptiveNonRepeating
+
+This section contains the record’s core descriptive fields. In the edanmdm schema it includes fields such as title_sort, title, data_source, record_ID, unit_code, record_link, guid, metadata_usage, and online_media. It's often used for canonical titles, record links or GUIDs, core media summaries, and unit and source attribution. 
+
+### indexedStructured
+
+This section contains normalized metadata fields typically used for faceting and structured search. In edanmdm it includes fields such as date, topic, object_type, place, scientific_name, taxonomic fields, geoLocation, and online_media_type. It's often used for search facets, place hierarchies, structured dates, and sort-oriented values.
+
+
+### freetext
+
+This section contains dynamically named freetext fields. In edanmdm, freetext ensures that any field name may appear, and each field maps to an array of objects containing at least label and content.Typically, freetext is used for human-readable display text, repeated labeled statements, and source text that doesn't fit an obvious or fixed field cleanly.
+
+In the [example record](edan_examples/edanmdm.json), freetext includes keys such as date, name, notes, place, publisher, dataSource, identifier, objectType, and physicalDescription.
+
+### descriptiveOptional
+This section contains additional descriptive information that is useful but not always required. In edanmdm it is minimal, but other schemas use it more heavily. Sometimes it's used for supplemental notes and optional display metadata.
 
 ## Directory Structure
+
 Schemas are organized into two directories based on data provenance.
 
 - **`/schemas/content`** — non-primary data ingested from external systems (e.g., TMS, ArchivesSpace)
@@ -16,6 +62,6 @@ Some schemas appear in both directories because the data shape can originate fro
 
 ## Useful Links
 
-* JSON formatting: <https://jsonlint.com>
-* JSON online validator: <https://json-schema-validator.herokuapp.com>
-* JSON schema maker: <https://jsonschema.net>
+* JSON formatting: [https://jsonlint.com](https://jsonlint.com)
+* JSON online validator: [https://json-schema-validator.herokuapp.com](https://json-schema-validator.herokuapp.com)
+* JSON schema maker: [https://jsonschema.net](https://jsonschema.net)

--- a/schemas/content/edanmdm.json
+++ b/schemas/content/edanmdm.json
@@ -33,7 +33,7 @@
 					"additionalProperties": false,
 					"properties": {
 						"mediaCount": {
-							"type": "string"
+							"type": "integer"
 						},
 						"media": {
 							"type": "array",
@@ -48,6 +48,9 @@
 								],
 								"additionalProperties": false,
 								"properties": {
+									"id": {
+										"type": "string"
+									},
 									"content": {
 										"type": "string"
 									},
@@ -83,6 +86,15 @@
 									},
 									"mime_type": {
 										"type": "string"
+									},
+									"altTextAccessibility": {
+										"type": "string"
+									},
+									"extDescrAccessibility": {
+										"type": "string"
+									},
+									"resources": {
+										"type": "array"
 									},
 									"usage": {
 										"title": "usage",


### PR DESCRIPTION
Replaced the brief schema note with detailed README docs explaining the EDAN record structure and content model. I kept on getting asked about data types and decided to add more information to contextualize things for viewers. Added a 'What an EDAN Record Looks Like' section (root envelope and content object), a 'How the Content Model Works' section describing top-level buckets (descriptiveNonRepeating, indexedStructured, freetext, descriptiveOptional) and their purposes, plus a 'Common Top-Level Content Buckets' section with examples and references to core.json and edanmdm.json.

LMK if this makes sense. Happy to edit to make this a bit more simple if useful. 